### PR TITLE
Improve expense tracker UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Group Expense Tracker</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
@@ -71,10 +72,28 @@
                 <div class="card">
                     <div class="card-body">
                         <h2 class="h4 card-title">Summary</h2>
-                        <ul id="summary-list" class="list-group"></ul>
+                        <div class="table-responsive">
+                            <table id="summary-table" class="table mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>From</th>
+                                        <th></th>
+                                        <th>To</th>
+                                        <th class="text-end">Amount</th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                        <p id="summary-text" class="mt-3"></p>
                     </div>
                 </div>
             </section>
+
+            <div class="text-end my-3">
+                <button id="save-btn" class="btn btn-primary me-2">Save</button>
+                <button id="clear-btn" class="btn btn-danger">Clear All</button>
+            </div>
         </main>
     </div>
 


### PR DESCRIPTION
## Summary
- add Bootstrap icons and table layout for summary
- show trash icons for deleting members and expenses
- timestamp expenses and format amounts with `Intl.NumberFormat`
- add Save and Clear All controls
- display settlement instructions in a table with natural language summary

## Testing
- `node -c app.js`
- `node -e "console.log('test run')"`

------
https://chatgpt.com/codex/tasks/task_e_688616c3856883288550e07069d6d339